### PR TITLE
feat(Server): support max middleware count

### DIFF
--- a/src/commands/server.js
+++ b/src/commands/server.js
@@ -241,12 +241,13 @@ exports.run = (options) => {
         const middlewareList = Object.keys(middlewareCache)
             .map(key => {
                 const middleware = middlewareCache[key];
-                return {
+                return middleware ? {
                     key,
                     middleware: middleware,
                     weight: middleware._visit / (now - middleware._timestamp) * 1000
-                };
+                } : null;
             })
+            .filter(v => v)
             .sort((a, b) =>  b.weight - a.weight);
         
         log(middlewareList.map(v => `${v.key} ${v.weight}`));


### PR DESCRIPTION
fix #1

1. 按照访问次数/访问间隔做权重排序，默认保留三个权重最高的 middleware；
2. 保留数量可通过 config.maxMiddleware 配置；
3. 修复了 middlewareCache 里多了个一份 'xxx.js.map' 引用的 bug。