### PR TITLE
ykit 配置文件中 server 配置增加 devHost 配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## @leeonfield/ykit
+
+>分叉原因：因开发需要，需要对当前的 ykit 的一些功能进行 fix 以及功能扩展，官方反馈比较慢。
+
+### ChangeLog
+- add: 增加 devHost，在 ykit 配置文件中 server 配置增加 devHost 配置，用于开发机环境开发自定义 host（当前 ykit 中的静态资源 host 配置写死了 127.0.0.1，不适用于开发机开发）
+
+
+
+
 # YKit [![CircleCI](https://circleci.com/gh/YMFE/ykit.svg?style=shield)](https://circleci.com/gh/YMFE/ykit)
 
 [ENGLISH DOC](./README-en.md)

--- a/lib/commands/server.js
+++ b/lib/commands/server.js
@@ -55,6 +55,7 @@ exports.run = function (options) {
         verbose = options.v || options.verbose,
         proxy = options.x || options.proxy,
         hot = options.hot === 'false' ? false : true,
+        devHost = '127.0.0.1',
         middlewares = options.mw || options.middlewares,
         isHttps = options.s || options.https,
         mapping = options.mapping || '',
@@ -289,8 +290,9 @@ exports.run = function (options) {
 
         // hot reload
         var hotEnabled = project.server && project.server.hot || hot;
+        var devHost = project.server && project.server.devHost || devHost;
         if (hotEnabled) {
-            ServerManager.setHotServer(webpackConfig, projectDir, projectName, port);
+            ServerManager.setHotServer(webpackConfig, projectDir, projectName, devHost, port);
         }
 
         // 如果发现插件中有 HotModuleReplacementPlugin 则需要编译全部入口，否则无法正常运行

--- a/lib/modules/ServerManager.js
+++ b/lib/modules/ServerManager.js
@@ -44,11 +44,11 @@ module.exports = {
             UtilFs.deleteFolderRecursive(sysPath.join(projectDir, YKIT_CACHE_DIR), true);
         }
     },
-    setHotServer: function setHotServer(webpackConfig, projectDir, projectName, port) {
+    setHotServer: function setHotServer(webpackConfig, projectDir, projectName, devHost, port) {
         if (!webpackConfig.output.local.publicPath) {
             // hot 且 未指定 publicPath 需要手动设置方式 hot.json 404
             var relativePath = sysPath.relative(projectDir, webpackConfig.output.local.path);
-            webpackConfig.output.local.publicPath = 'http://127.0.0.1:' + port + '/' + projectName + '/' + relativePath + '/';
+            webpackConfig.output.local.publicPath = 'http://' + devHost + ':' + port + '/' + projectName + '/' + relativePath + '/';
         }
 
         webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
@@ -60,7 +60,7 @@ module.exports = {
                     var entryItem = webpackConfig.entry[key];
                     if (sysPath.extname(entryItem[entryItem.length - 1]) === '.js') {
                         var whmPath = require.resolve('webpack-hot-middleware/client');
-                        var hotPath = 'http://127.0.0.1:' + port + '/__webpack_hmr';
+                        var hotPath = 'http://' + devHost + ':' + port + '/__webpack_hmr';
                         entryItem.unshift(whmPath + '?reload=true&path=' + hotPath + '&timeout=9999999&overlay=false');
                     }
                     return entryItem;
@@ -71,7 +71,7 @@ module.exports = {
     getCompiler: function getCompiler(shouldCompileAll, reqUrl, skipCompile, callback) {
         var _this = this;
 
-        return (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee() {
+        return (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee() {
             var webpackConfig, entries, isExtractTextPluginExists, entryNum;
             return _regenerator2.default.wrap(function _callee$(_context) {
                 while (1) {

--- a/src/commands/server.js
+++ b/src/commands/server.js
@@ -45,6 +45,7 @@ exports.run = (options) => {
         verbose = options.v || options.verbose,
         proxy = options.x || options.proxy,
         hot = options.hot === 'false' ? false : true,
+        devHost = '127.0.0.1',
         middlewares = options.mw || options.middlewares,
         isHttps = options.s || options.https,
         mapping = options.mapping || '',
@@ -280,8 +281,9 @@ exports.run = (options) => {
 
         // hot reload
         const hotEnabled = (project.server && project.server.hot) || hot;
+        const devHost =  (project.server && project.server.devHost) || devHost;
         if(hotEnabled) {
-            ServerManager.setHotServer(webpackConfig, projectDir, projectName, port);
+            ServerManager.setHotServer(webpackConfig, projectDir, projectName, devHost, port);
         }
 
         // 如果发现插件中有 HotModuleReplacementPlugin 则需要编译全部入口，否则无法正常运行

--- a/src/modules/ServerManager.js
+++ b/src/modules/ServerManager.js
@@ -22,11 +22,11 @@ module.exports = {
             UtilFs.deleteFolderRecursive(sysPath.join(projectDir, YKIT_CACHE_DIR), true);
         }
     },
-    setHotServer(webpackConfig, projectDir, projectName, port) {
+    setHotServer(webpackConfig, projectDir, projectName, devHost, port) {
         if (!webpackConfig.output.local.publicPath) {
             // hot 且 未指定 publicPath 需要手动设置方式 hot.json 404
             const relativePath = sysPath.relative(projectDir, webpackConfig.output.local.path);
-            webpackConfig.output.local.publicPath = `http://127.0.0.1:${port}/${projectName}/${relativePath}/`;
+            webpackConfig.output.local.publicPath = `http://${devHost}:${port}/${projectName}/${relativePath}/`;
         }
 
         webpackConfig.plugins.push(new webpack.HotModuleReplacementPlugin());
@@ -38,7 +38,7 @@ module.exports = {
                     let entryItem = webpackConfig.entry[key];
                     if(sysPath.extname(entryItem[entryItem.length - 1]) === '.js') {
                         const whmPath = require.resolve('webpack-hot-middleware/client');
-                        const hotPath = `http://127.0.0.1:${port}/__webpack_hmr`;
+                        const hotPath = `http://${devHost}:${port}/__webpack_hmr`;
                         entryItem.unshift(whmPath + '?reload=true&path=' + hotPath + '&timeout=9999999&overlay=false');
                     }
                     return entryItem;


### PR DESCRIPTION
当前 ykit 中的静态资源 host 配置写死了 127.0.0.1，不适用于开发机开发
本次提交在 ykit 配置文件中 server 配置增加 devHost 配置，用于开发机环境开发自定义 host